### PR TITLE
docs(storybook): fixes broken icons

### DIFF
--- a/.storybook/leaflet-react-theme.js
+++ b/.storybook/leaflet-react-theme.js
@@ -1,5 +1,8 @@
 import { create } from '@storybook/theming';
 
+import GithubIconUrl from '../stories/assets/github-icon.png'
+import LeafletReactFibersIconUrl from '../stories/assets/leaflet-react-fibers.png'
+
 // setup the theme based on browser preference
 let base = 'light'
 if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
@@ -49,11 +52,11 @@ export default create({
   brandTitle:
     `<span style="display: block">
       <span style="display: flex; align-items: center; justify-content: center; margin-bottom: 0.25rem;">
-        <img src="/leaflet-react-fibers.png" style="width: 1.25rem; margin-right: 0.5rem;"/> 
+        <img src="${LeafletReactFibersIconUrl}" style="width: 1.25rem; margin-right: 0.5rem;"/> 
         leaflet-react-fibers
       </span>
       <span style="font-size: x-small; font-weight: normal; display: flex; align-items: center; justify-content: center">
-        <img src="/github-icon.png" style="width: 0.8rem; margin-right: 0.5rem; ${base === 'dark' ? 'filter: invert(1)' : ''}"/> 
+        <img src="${GithubIconUrl}" style="width: 0.8rem; margin-right: 0.5rem; ${base === 'dark' ? 'filter: invert(1)' : ''}"/> 
         Click for github
       </span>
     </span>`

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -10,6 +10,5 @@ module.exports = {
   core: {
     builder: 'webpack5',
     disableTelemetry: true
-  },
-  staticDirs: ['../stories/assets'],
+  }
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See [Docs](https://chickencoding123.github.io/leaflet-react-fibers) for various 
 
 ### JSX renderer
 You must provide a JSX renderer when embedding HTML in `lfPopup` or `lfTooltip` otherwise their contents are ignored, this is by design:
->:info: You do NOT have to use `react-dom`, any JSX renderer will suffice. 
+>:information_source: You do NOT have to use `react-dom`, any JSX renderer will suffice. 
 ```tsx
 import { LeafletMap, L } from "leaflet-react-fibers"
 import ReactDOM from "react-dom"
@@ -55,7 +55,7 @@ None of the libraries mentioned below provide mutability control out of the box 
 2. [react-leaflet](https://github.com/PaulLeCam/react-leaflet) react wrapper for leaflet which comes with hooks.
 
 ## Known Issues
-[ ] Mutability control does not work at the moment. This is a feature of this library that allows a layer to be explicitly mutable or immutable using a `mutable` prop.
+[x] Mutability control does not work at the moment. This is a feature of this library that allows a layer to be explicitly mutable or immutable using a `mutable` prop.
 
 ## Development
 Clone this repository and simply run `npm run storybook` to get started.

--- a/examples/populated-places.tsx
+++ b/examples/populated-places.tsx
@@ -67,7 +67,7 @@ const PopulatedPlaces = ({ geoJson, mapHeight }: Partial<PopulatedPlacesProps> =
         }}
       >
 
-        <lfTilesWMS baseUrl="http://ows.mundialis.de/services/service?" options={{
+        <lfTilesWMS baseUrl="https://ows.mundialis.de/services/service?" options={{
           layers: 'TOPO-WMS',
           format: 'image/png',
           noWrap: true,

--- a/examples/usa.tsx
+++ b/examples/usa.tsx
@@ -99,7 +99,7 @@ const WyomingExtended = ({ color }: { color: string }) => {
   )
 }
 
-export const WMS_BASE_URL = 'http://ows.mundialis.de/services/service'
+export const WMS_BASE_URL = 'https://ows.mundialis.de/services/service'
 export interface USAProps {
   isVisible: boolean
   zPosition: 'top' | 'middle' | 'bottom'


### PR DESCRIPTION
Also fixed a github emojicon in `README.md`  which was not shown. Another fix is for tile providers to use `https`.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/chickencoding123/leaflet-react-fibers/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Style
- [ ] Build-related changes
- [x] Other, please describe:

Storybook and `README.md`

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/chidkencoding123/leaflet-react-fibers/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included
- [x] You **REMOVED** `.only` modifier from the tests, if any

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
